### PR TITLE
Add Dockerfile and Cargo-Make target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Rust build artifacts
+target
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Git
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM rust:1.67-bullseye AS chef
+
+RUN cargo install cargo-chef; \
+    rustup component add rustfmt;
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+# RUN cargo build --release --bin chainsaw-demo-grpc
+RUN cargo build --release
+
+FROM debian:bullseye-slim AS base-runtime
+# Running apt again here to install common certificate authorites on the
+# base-runtime target.
+#
+# The previous install including `cmake` is dropped as this layer is independent
+# of the previous.
+RUN apt-get update
+RUN apt-get install ca-certificates -y
+
+WORKDIR /app
+COPY cactuar.toml cactuar.toml
+
+FROM base-runtime AS cactuar
+COPY --from=builder --chown=root:root /app/target/release/controller /usr/local/bin/
+
+EXPOSE 3000
+CMD ["controller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,4 @@ COPY cactuar.toml cactuar.toml
 FROM base-runtime AS cactuar
 COPY --from=builder --chown=root:root /app/target/release/controller /usr/local/bin/
 
-EXPOSE 3000
 CMD ["controller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,22 +13,12 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-# RUN cargo build --release --bin chainsaw-demo-grpc
 RUN cargo build --release
 
-FROM debian:bullseye-slim AS base-runtime
-# Running apt again here to install common certificate authorites on the
-# base-runtime target.
-#
-# The previous install including `cmake` is dropped as this layer is independent
-# of the previous.
-RUN apt-get update
-RUN apt-get install ca-certificates -y
+FROM gcr.io/distroless/cc AS cactuar
 
 WORKDIR /app
 COPY cactuar.toml cactuar.toml
-
-FROM base-runtime AS cactuar
 COPY --from=builder --chown=root:root /app/target/release/controller /usr/local/bin/
 
 CMD ["controller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rust:1.67-bullseye AS chef
 
+# Use cargo-chef to cache Rust dependency builds for Docker, it's bad the
+# environment to spin your CPU that much on every Docker build!
 RUN cargo install cargo-chef; \
     rustup component add rustfmt;
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ FROM gcr.io/distroless/cc AS cactuar
 
 WORKDIR /app
 COPY cactuar.toml cactuar.toml
-COPY --from=builder --chown=root:root /app/target/release/controller /usr/local/bin/
+COPY --from=builder --chown=root:root /app/target/release/controller /
 
-CMD ["controller"]
+CMD ["/controller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67-bullseye AS chef
+FROM rust:1.67 AS chef
 
 # Use cargo-chef to cache Rust dependency builds for Docker, it's bad the
 # environment to spin your CPU that much on every Docker build!

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,10 +4,16 @@
 #
 # Install cargo-make to run these tasks:
 #   cargo install cargo-make --force
+# 
+# After installation, to run a task:
+#   cargo make <task>
 
 [config]
 default_to_workspace = false
 skip_core_tasks = true
+
+[env]
+CACTUAR_DOCKER_TARGET = "cactuar"
 
 [tasks.test]
 command = "cargo"
@@ -22,3 +28,14 @@ install_crate = "cargo-llvm-cov"
 [tasks.docs]
 command = "cargo"
 args = ["doc"]
+
+[tasks.docker]
+command = "docker"
+args = [
+    "build",
+    "--tag", # tag and target are currently the same
+    "${CACTUAR_DOCKER_TARGET}",
+    "--target",
+    "${CACTUAR_DOCKER_TARGET}",
+    ".", # build context
+]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,7 +34,7 @@ command = "docker"
 args = [
     "build",
     "--tag", # tag and target are currently the same
-    "${CACTUAR_DOCKER_TARGET}",
+    "${CACTUAR_DOCKER_TARGET}:${CARGO_MAKE_GIT_HEAD_LAST_COMMIT_HASH_PREFIX}",
     "--target",
     "${CACTUAR_DOCKER_TARGET}",
     ".", # build context

--- a/k3d-conf.yaml
+++ b/k3d-conf.yaml
@@ -20,6 +20,6 @@ registries: # define how registries should be created or used
 options:
     k3s: # options passed on to K3s itself
         extraArgs: # additional arguments passed to the `k3s server|agent` command; same as `--k3s-arg`
-            - arg: --no-deploy=traefik
+            - arg: --disable=traefik
               nodeFilters:
                 - server:*

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Debug,
-    net::{IpAddr, SocketAddr},
-};
+use std::fmt::Debug;
 
 use config::{Config, ValueKind};
 use serde::Deserialize;


### PR DESCRIPTION
This moves us closer towards getting this running this in-cluster. Docker images are tagged `cactuar:<git-hash-prefix>` when built using the `cargo-make` task. Which can be run like so:
```bash
cargo make docker
```

Currently, we don't need to expose any API surfaces so no ports are exposed.

I've also included a change to the `k3d-conf.yaml` since `--no-deploy` has been deprecated and replaced with `--disable`