### PR TITLE
Resolve dependabot alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,9 +2141,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2157,7 +2157,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main_crdgen.rs"
 
 [dependencies]
 # async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.25", features = ["full"] }
 futures = "*" # use the futures version pulled in by tokio
 
 # kubernetes dependencies


### PR DESCRIPTION
Dependabot detected some vulnerabilities due to an out-of-date version of Tokio. This PR upgrades Tokio to resolve.