### PR TITLE
Support multiple metric types

### DIFF
--- a/src/service_alerts.rs
+++ b/src/service_alerts.rs
@@ -26,7 +26,26 @@ pub const FINALIZER_NAME: &str = "servicealert.cactuar.rs";
 pub struct ServiceAlertSpec {
     pub common_labels: HashMap<String, String>,
     pub deployment_name: String,
+    pub metric_type: MetricType,
     pub alerts: HashMap<Alerts, Vec<AlertConfig>>,
+}
+
+
+// Since the metrics are different for different protocols, we must map each Alerts enum
+// to a different expression string in prometheus land.
+// e.g.
+// REST + ErrorPercent uses the istio_requests_total         istio standard metric
+// gRPC + ErrorPercent uses the istio_request_messages_total istio standard metric
+// TODO: TCP has no equivalent, so we must handle that at a later date
+// see https://istio.io/latest/docs/reference/config/metrics/ for more information
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, Hash)]
+pub enum MetricType {
+    #[serde(rename = "gRPC")]
+    GRPC,
+    #[serde(rename = "REST")]
+    REST,
+    // #[serde(rename = "TCP")]
+    // TCP,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, Hash)]

--- a/src/service_alerts.rs
+++ b/src/service_alerts.rs
@@ -71,7 +71,8 @@ pub enum HttpAlerts {
 #[serde(rename_all = "camelCase")]
 pub enum MiscAlerts {
     AllReplicasDown,
-    LowReplicaCount
+    LowReplicaCount,
+    PodsFrequentlyRestarting,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]


### PR DESCRIPTION
Keen to hear thoughts on this approach. We could alternatively have 
```yaml
alerts:
    gRPC:
        - <alert>
        - <alert>
    REST:
        - <alert>
        - <alert>
```
In case services expose two types of services, but equally they could simply supply two ServiceAlert resources.

I am assuming we will want some kind of way to provide deploy time validation, since I'd say that's a requirement for TCP services (given they can't have the same set of alerts as REST/gRPC). Equally, I'm not sure what TCP alerting might look like