### PR TITLE
Properly support default config values and document

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,6 @@ use serde::Deserialize;
 /// implementation of it.
 pub struct CactuarConfig {
     pub log: Log,
-
     pub http: HTTP,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,28 +1,73 @@
+//! # Cactuar Config
+//!
+//! This module defines the configuration structure for Cactuar, and implements
+//! support for merging a final config from various information sources. In
+//! order of priority (i.e. item in list *overrides* the next item in list),
+//! config sources are merged as follows:
+//!
+//! - Environment variables
+//! - Config file: `cactuar.toml`
+//! - Default values
+//!
+//! ## Examples
+//!
+//! ### Environment variables
+//!
+//! ```bash
+//! HTTP_ADDRESS=127.0.0.1 \
+//! HTTP_PORT=80 \
+//! LOG_LEVEL=debug \
+//! cargo run --bin controller
+//! ```
+//!
+//! ### Config file: `cactuar.toml`
+//!
+//! ```toml
+//! [log]
+//! level = "info"
+//!
+//! [http]
+//! address = "0.0.0.0"
+//! port = 8080
+//! ```
+
 use std::{
     fmt::Debug,
     net::{IpAddr, SocketAddr},
 };
 
-use config::{Config, ValueKind};
+use config::Config;
 use serde::Deserialize;
 
-const DEFAULT_LOG_LEVEL: &str = "info";
-
-#[derive(Debug, Deserialize)]
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+/// Forms the tree structure for CactuarConfig. This implementation relies on
+/// using the [`Default`] trait, along with the `#[serde(default)]` annotation
+/// macro to provide default values for each config value.
+///
+/// If you need to add a new config value, make sure you either derive
+/// [`Default`] if all your sub-types implement the trait, or provide your own
+/// implementation of it.
 pub struct CactuarConfig {
     pub log: Log,
 
     pub http: HTTP,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Default, Debug, Deserialize)]
+/// This struct contains a [`LogLevel`] enum in order to provide the serialised
+/// structure we expect.
+///
+/// It also provides the environment variable naming, i.e. Log { level }
+/// becomes: LOG_LEVEL
 pub struct Log {
-    #[serde(default)]
     pub level: LogLevel,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+/// Our own representation of logging levels to decouple from the
+/// [`tracing::Level`] representations.
 pub enum LogLevel {
     Error,
     Warn,
@@ -31,9 +76,14 @@ pub enum LogLevel {
     Trace,
 }
 
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct HTTP {
-    #[serde(default = "default_serve_address")]
     pub address: IpAddr,
     pub port: u16,
 }
@@ -44,6 +94,19 @@ impl HTTP {
     }
 }
 
+// By default, Cactuar should expect external clients, and thus should bind to
+// `0.0.0.0`. Port `8080` is simply commonly used as a non-standard HTTP port.
+impl Default for HTTP {
+    fn default() -> Self {
+        Self {
+            address: [0, 0, 0, 0].into(),
+            port: 8080,
+        }
+    }
+}
+
+// We want to be able to convert our `LogLevel` enum to their [`tracing::Level`]
+// representation, so we implement the [`From`] trait here.
 impl From<LogLevel> for tracing::Level {
     fn from(level: LogLevel) -> Self {
         match level {
@@ -56,28 +119,16 @@ impl From<LogLevel> for tracing::Level {
     }
 }
 
-impl Default for LogLevel {
-    fn default() -> Self {
-        Self::Info
-    }
-}
-
 impl CactuarConfig {
-    /// Reads application configuration from either a `config.toml` file, or from
-    /// environment variables.
+    /// Create a new [`CactuarConfig`]. This function merges default config
+    /// values, config file values, and environment variables, please refer to
+    /// the [`config module documentation`](crate::config) for more information.
     pub fn new() -> Result<CactuarConfig, config::ConfigError> {
         let builder = Config::builder()
             .add_source(config::File::with_name("cactuar").required(false))
             .add_source(config::Environment::default().separator("_"))
-            .set_default("log.level", ValueKind::String(DEFAULT_LOG_LEVEL.into()))?
             .build()?;
 
         builder.try_deserialize()
     }
-}
-
-fn default_serve_address() -> IpAddr {
-    "0.0.0.0"
-        .parse()
-        .expect("failed to parse default grpc address")
 }

--- a/src/http/router.rs
+++ b/src/http/router.rs
@@ -1,6 +1,6 @@
 use axum::routing;
 use color_eyre::Result;
-use prometheus::{process_collector::ProcessCollector, Registry};
+use prometheus::Registry;
 
 use super::{prometheus_handler, readiness_handler};
 
@@ -10,9 +10,7 @@ const METRICS_PATH: &str = "/metrics";
 
 /// Produces top level HTTP router that can be exposed by an [`axum::Server`]
 pub fn router() -> Result<axum::Router> {
-    let process_collector = ProcessCollector::for_self();
     let prometheus_registry = Registry::new();
-    prometheus_registry.register(Box::new(process_collector))?;
 
     Ok(axum::Router::new()
         .route(READINESS_CHECK_PATH, routing::get(readiness_handler))


### PR DESCRIPTION
Also removes the Prometheus process collector for now, as this only supports Linux targets, which makes building on MacOS annoying.