### PR TITLE
Alert Conversion Architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "hyper",
  "k8s-openapi",
  "kube",
+ "nanoid",
  "pretty_assertions",
  "prometheus",
  "schemars",
@@ -1392,6 +1393,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ prometheus = { version = "0.13.3", features = ["process"] }
 # configuration
 config = "0.13"
 
+# temporary until we figure out various alert details to map to queries and
+# provide a unique identifier
+nanoid = "0.4.0"
+
 [dependencies.uuid]
 version = "1.3.0"
 features = ["v4", "fast-rng", "macro-diagnostics"]

--- a/src/prometheus/mod.rs
+++ b/src/prometheus/mod.rs
@@ -6,3 +6,4 @@
 //! Prometheus alert that Cactuar can produce as a Kubernetes `ConfigMap`.
 
 pub mod alert;
+pub mod replica_alerts;

--- a/src/prometheus/replica_alerts.rs
+++ b/src/prometheus/replica_alerts.rs
@@ -1,0 +1,67 @@
+use std::fmt::format;
+
+use crate::service_alerts::{AlertConfig, Operation, ServiceAlertSpec};
+
+use super::alert::{
+    AlertGroup, AlertRules, Annotations, Labels, PrometheusSeverity, PLACEHOLDER_VALUE,
+};
+
+pub fn produce_replica_alerts(
+    alert_configs: &Vec<AlertConfig>,
+    spec: &ServiceAlertSpec,
+) -> AlertGroup {
+    let replica_rules = alert_configs
+        .iter()
+        .map(|conf| AlertRules {
+            alert: unique_name(&conf),
+            expr: replicas_promql(&conf, &spec),
+            for_: conf.for_.clone(),
+            labels: Labels {
+                severity: PrometheusSeverity::from(&conf.alert_with_labels),
+                source: spec.common_labels.origin.clone(),
+                owner: spec.common_labels.owner.clone(),
+            },
+            annotations: Annotations {
+                summary: PLACEHOLDER_VALUE.into(),
+                description: PLACEHOLDER_VALUE.into(),
+            },
+        })
+        .collect();
+
+    AlertGroup {
+        name: PLACEHOLDER_VALUE.into(),
+        rules: replica_rules,
+    }
+}
+
+// Since the metrics are different for different protocols, we must map each Alerts enum
+// to a different expression string in prometheus land.
+// e.g.
+// REST + ErrorPercent uses the istio_requests_total         istio standard metric
+// gRPC + ErrorPercent uses the istio_request_messages_total istio standard metric
+//
+// Example query (all replicas down):
+// sum by (app_kubernetes_io_name) (up{app_kubernetes_io_name="software-catalog-grpc"}) == 0
+struct PromQL {
+    aggr: String,
+}
+
+fn unique_name(alert_config: &AlertConfig) -> String {
+    format!("foo-{0}", nanoid::nanoid!())
+}
+
+fn replicas_promql(alert_config: &AlertConfig, spec: &ServiceAlertSpec) -> String {
+    match alert_config.operation {
+        Operation::EqualTo => {
+            format!(
+                r#"sum by (app_kubernetes_io_name) (up{{app_kubernetes_io_name="{0}"}}) == {1}"#,
+                spec.deployment_name, alert_config.value,
+            )
+        }
+        Operation::LessThan => format!(
+            r#"sum by (app_kubernetes_io_name) (up{{app_kubernetes_io_name="{0}"}}) < {1}"#,
+            spec.deployment_name, alert_config.value,
+        ),
+        Operation::MoreThan => format!(""),
+    }
+}

--- a/src/service_alerts.rs
+++ b/src/service_alerts.rs
@@ -72,14 +72,6 @@ pub struct ServiceAlertStatus {
     pub reconciliation_expires_at: Option<String>,
 }
 
-// impl TryFrom<ServiceAlertSpec> for alert::Alerts {
-//     type Error = String;
-
-//     fn try_from(value: ServiceAlertSpec) -> Result<Self, Self::Error> {
-//         todo!()
-//     }
-// }
-
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;

--- a/src/service_alerts.rs
+++ b/src/service_alerts.rs
@@ -21,9 +21,17 @@ pub const FINALIZER_NAME: &str = "servicealert.cactuar.rs";
     namespaced
 )]
 pub struct ServiceAlertSpec {
-    pub common_labels: HashMap<String, String>,
+    pub common_labels: CommonLabels,
     pub deployment_name: String,
     pub alerts: HashMap<Alerts, Vec<AlertConfig>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq)]
+pub struct CommonLabels {
+    pub owner: String,
+    pub origin: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, Hash)]


### PR DESCRIPTION
I need to think some more about this but I'm trying to lay out the more code in order to properly generate more of Prometheus output from our input CRDs. Currently, here's what this branch is capable of producing from `example-custom-resource.yaml`:
```yaml
Data
====
bar:
----
groups:
- name: PLACEHOLDER
  rules:
  - alert: foo-Va4HNoCnj6_YEARW-oGrd
    expr: sum by (app_kubernetes_io_name) (up{app_kubernetes_io_name="best-service-eu"}) < 3
    for: 3m
    labels:
      severity: warning
      source: cloud
      owner: bar
    annotations:
      summary: PLACEHOLDER
      description: PLACEHOLDER
  - alert: foo-zJ2ag-3vQFBwxjUUF6p2w
    expr: sum by (app_kubernetes_io_name) (up{app_kubernetes_io_name="best-service-eu"}) == 0
    for: 0m
    labels:
      severity: critical
      source: cloud
      owner: bar
    annotations:
      summary: PLACEHOLDER
      description: PLACEHOLDER
```
Generated:
- [x] alert (needs thinking on how to generate unique identifiers within the local map, probably 1:1 with `expr`)
- [x] expr (needs thinking on layout and probably more complicated queries)
- [x] for
- [x] labels
- [ ] annotations